### PR TITLE
Add operator== and std::hash specialization for upa::url

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -626,6 +626,8 @@ private:
     std::size_t path_segment_count_ = 0;
     detail::url_search_params_ptr search_params_ptr_;
 
+    friend bool operator==(const url& lhs, const url& rhs);
+    friend struct std::hash<url>;
     friend detail::url_serializer;
     friend detail::url_setter;
     friend detail::url_parser;
@@ -2927,6 +2929,11 @@ inline bool is_unc_path(const CharT* first, const CharT* last)
 
 // URL utilities (non-member functions)
 
+/// @brief Lexicographically compares two URL's
+inline bool operator==(const url& lhs, const url& rhs) {
+    return lhs.norm_url_ == rhs.norm_url_;
+}
+
 /// @brief Swaps the contents of two URLs
 ///
 /// Swaps the contents of the @a lhs and @a rhs URLs
@@ -3001,6 +3008,15 @@ inline url url_from_file_path(StrT&& str) {
 
 
 } // namespace upa
+
+
+/// @brief std::hash specialization for upa::url class
+template<>
+struct std::hash<upa::url> {
+    std::size_t operator()(const upa::url& url) const noexcept {
+        return std::hash<std::string>{}(url.norm_url_);
+    }
+};
 
 // Includes that require the url class declaration
 #include "url_search_params-inl.h"

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -6,6 +6,7 @@
 #include "upa/url.h"
 #include "doctest-main.h"
 #include "test-utils.h"
+#include <unordered_map>
 
 
 std::string urls_to_str(const char* s1) {
@@ -565,4 +566,21 @@ TEST_CASE("url_from_file_path") {
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\?\\Volume{b75e2c83-0000-0000-0000-602f00000000}\\Test\\Foo.txt"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\.\\Volume{b75e2c83-0000-0000-0000-602f00000000}\\Test\\Foo.txt"), upa::url_error);
     }
+}
+
+// Test operator== and std::hash specialization
+
+TEST_CASE("operator== && std::hash<upa::url>") {
+    std::unordered_map<upa::url, int> map;
+
+    map.emplace(upa::url{ "about:blank" }, 1);
+    map.emplace(upa::url{ "file:///path" }, 2);
+    map.emplace(upa::url{ "https://example.org/" }, 3);
+
+    CHECK(map.at(upa::url{ "about:blank" }) == 1);
+    CHECK(map.at(upa::url{ "file:///path" }) == 2);
+    CHECK(map.at(upa::url{ "https://example.org/" }) == 3);
+
+    CHECK(upa::url{ "about:blank" } == upa::url{ "about:blank" });
+    CHECK_FALSE(upa::url{ "about:blank" } == upa::url{ "https://example.org/" });
 }


### PR DESCRIPTION
This allows to use `upa::url` as key in unordered containers.