### PR TITLE
Update Doxygen workflow, fix spelling in docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   deploy:
@@ -17,6 +18,7 @@ jobs:
       - uses: mattnotmitt/doxygen-action@edge
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: upa-url/docs

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ find_package(upa REQUIRED)
 target_link_libraries(exe-target PRIVATE upa::url)
 ```
 
-#### Embeding
+#### Embedding
 
 The entire library source tree can be placed in subdirectory (say `url/`) of your project and then included in it with `add_subdirectory()`:
 ```cmake
@@ -57,7 +57,7 @@ add_subdirectory(url)
 target_link_libraries(exe-target PRIVATE upa::url)
 ```
 
-#### Embeding with FetchContent
+#### Embedding with FetchContent
 
 ```cmake
 include(FetchContent)

--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -78,7 +78,7 @@ public:
     ///
     /// Throws @a url_error exception on parse error.
     ///
-    /// @param[in] args Host string to parse
+    /// @param[in] str Host string to parse
     template <class StrT, enable_if_str_arg_t<StrT> = 0>
     explicit url_host(StrT&& str) {
         host_out out(*this);


### PR DESCRIPTION
* Run Doxygen workflow on pull request, but publish docs only on push to main branch
* fix spelling
* fix doxygen comment of `url_host::url_host(StrT&& str)`