### PR TITLE
Rename all CamelCase functions to snake_case in the url_percent_encode.h

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -2184,7 +2184,7 @@ inline validation_errc url_parser::url_parse(url_serializer& urls, const CharT* 
             } else {
                 // Just append the 7-bit character, possibly escaping it.
                 const auto uc = static_cast<unsigned char>(uch);
-                if (!detail::isCharInSet(uc, query_cpset))
+                if (!detail::is_char_in_set(uc, query_cpset))
                     detail::AppendEscapedChar(uch, str_query);
                 else
                     str_query.push_back(uc);
@@ -2219,7 +2219,7 @@ inline validation_errc url_parser::url_parse(url_serializer& urls, const CharT* 
             } else {
                 // Just append the 7-bit character, possibly escaping it.
                 const auto uc = static_cast<unsigned char>(uch);
-                if (detail::isCharInSet(uc, fragment_no_encode_set)) {
+                if (detail::is_char_in_set(uc, fragment_no_encode_set)) {
                     str_frag.push_back(uc);
                 } else {
                     // other characters are escaped
@@ -2333,7 +2333,7 @@ inline bool url_parser::do_path_segment(const CharT* pointer, const CharT* last,
         } else {
             // Just append the 7-bit character, possibly escaping it.
             const auto uc = static_cast<unsigned char>(uch);
-            if (!detail::isCharInSet(uc, path_no_encode_set))
+            if (!detail::is_char_in_set(uc, path_no_encode_set))
                 detail::AppendEscapedChar(uc, output);
             else
                 output.push_back(uc);

--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -286,7 +286,7 @@ inline validation_errc host_parser::parse_opaque_host(const CharT* first, const 
     std::string& str_host = dest.hostStart();
 
     //TODO: UTF-8 percent encode it using the C0 control percent-encode set
-    //detail::AppendStringOfType(first, last, detail::CHAR_C0_CTRL, str_host);
+    //detail::append_utf8_percent_encoded(first, last, detail::CHAR_C0_CTRL, str_host);
     using UCharT = typename std::make_unsigned<CharT>::type;
 
     const CharT* pointer = first;
@@ -295,11 +295,11 @@ inline validation_errc host_parser::parse_opaque_host(const CharT* first, const 
         const auto uch = static_cast<UCharT>(*pointer);
         if (uch >= 0x7f) {
             // invalid utf-8/16/32 sequences will be replaced with 0xfffd
-            detail::AppendUTF8EscapedChar(pointer, last, str_host);
+            detail::append_utf8_percent_encoded_char(pointer, last, str_host);
         } else {
             // Just append the 7-bit character, escaping C0 control chars:
             if (uch <= 0x1f)
-                detail::AppendEscapedChar(uch, str_host);
+                detail::append_percent_encoded_byte(uch, str_host);
             else
                 str_host.push_back(static_cast<unsigned char>(uch));
             ++pointer;

--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -216,7 +216,7 @@ inline validation_errc host_parser::parse_host(const CharT* first, const CharT* 
             }
             // uch == '%'
             unsigned char uc8; // NOLINT(cppcoreguidelines-init-variables)
-            if (detail::DecodeEscaped(it, last, uc8)) {
+            if (detail::decode_hex_to_byte(it, last, uc8)) {
                 if (uc8 < 0x80) {
                     buff_uc.push_back(static_cast<char16_t>(uc8));
                     continue;
@@ -227,7 +227,7 @@ inline validation_errc host_parser::parse_host(const CharT* first, const CharT* 
                 buff_utf8.push_back(static_cast<char>(uc8));
                 while (it != last && *it == '%') {
                     ++it; // skip '%'
-                    if (!detail::DecodeEscaped(it, last, uc8))
+                    if (!detail::decode_hex_to_byte(it, last, uc8))
                         uc8 = '%';
                     buff_utf8.push_back(static_cast<char>(uc8));
                 }

--- a/include/upa/url_ip.h
+++ b/include/upa/url_ip.h
@@ -56,7 +56,7 @@ static inline bool hostname_ends_in_a_number(const CharT* first, const CharT* la
         if (len) {
             if (len >= 2 && start_of_label[0] == '0' && (start_of_label[1] == 'X' || start_of_label[1] == 'x')) {
                 // "0x" is valid IPv4 number (std::all_of returns true if the range is empty)
-                return std::all_of(start_of_label + 2, last, detail::isHexChar<CharT>);
+                return std::all_of(start_of_label + 2, last, detail::is_hex_char<CharT>);
             }
             // decimal or octal number?
             return std::all_of(start_of_label, last, detail::is_ascii_digit<CharT>);
@@ -131,7 +131,7 @@ static inline validation_errc ipv4_parse_number(const CharT* first, const CharT*
         for (auto it = first; it != last; ++it) {
             // This cast is safe because chars are ASCII
             const auto uch = static_cast<unsigned char>(*it);
-            if (!detail::isHexChar(uch))
+            if (!detail::is_hex_char(uch))
                 return validation_errc::ipv4_non_numeric_part;
             num = num * radix + detail::HexCharToValue(uch);
         }
@@ -180,7 +180,7 @@ inline validation_errc ipv4_parse(const CharT* first, const CharT* last, uint32_
                 // 1. If input is the empty string, then return failure.
                 return validation_errc::ipv4_non_numeric_part;
             part[++dot_count] = it + 1; // skip '.'
-        } else if (!detail::isIPv4Char(uc)) {
+        } else if (!detail::is_ipv4_char(uc)) {
             // non IPv4 character
             return validation_errc::ipv4_non_numeric_part;
         }
@@ -240,7 +240,7 @@ void ipv4_serialize(uint32_t ipv4, std::string& output);
 template <typename IntT, typename CharT>
 inline IntT get_hex_number(const CharT*& pointer, const CharT* last) {
     IntT value = 0;
-    while (pointer != last && detail::isHexChar(*pointer)) {
+    while (pointer != last && detail::is_hex_char(*pointer)) {
         const auto uc = static_cast<unsigned char>(*pointer);
         value = value * 0x10 + detail::HexCharToValue(uc);
         ++pointer;
@@ -272,7 +272,7 @@ inline validation_errc ipv6_parse(const CharT* first, const CharT* last, uint16_
         case '.':
             return validation_errc::ipv4_in_ipv6_invalid_code_point; // (6-5-1)
         default:
-            return detail::isHexChar(first[0])
+            return detail::is_hex_char(first[0])
                 ? validation_errc::ipv6_too_few_pieces // (8)
                 : validation_errc::ipv6_invalid_code_point; // (6-7)
         }

--- a/include/upa/url_ip.h
+++ b/include/upa/url_ip.h
@@ -133,7 +133,7 @@ static inline validation_errc ipv4_parse_number(const CharT* first, const CharT*
             const auto uch = static_cast<unsigned char>(*it);
             if (!detail::is_hex_char(uch))
                 return validation_errc::ipv4_non_numeric_part;
-            num = num * radix + detail::HexCharToValue(uch);
+            num = num * radix + detail::hex_char_to_num(uch);
         }
     }
 
@@ -242,7 +242,7 @@ inline IntT get_hex_number(const CharT*& pointer, const CharT* last) {
     IntT value = 0;
     while (pointer != last && detail::is_hex_char(*pointer)) {
         const auto uc = static_cast<unsigned char>(*pointer);
-        value = value * 0x10 + detail::HexCharToValue(uc);
+        value = value * 0x10 + detail::hex_char_to_num(uc);
         ++pointer;
     }
     return value;

--- a/include/upa/url_percent_encode.h
+++ b/include/upa/url_percent_encode.h
@@ -347,17 +347,17 @@ extern const code_points_multiset code_points;
 // Check char is in predefined set
 
 template <typename CharT>
-inline bool isCharInSet(CharT c, const code_point_set& cpset) {
+inline bool is_char_in_set(CharT c, const code_point_set& cpset) {
     return cpset[c];
 }
 
 template <typename CharT>
-inline bool isIPv4Char(CharT c) {
+inline bool is_ipv4_char(CharT c) {
     return code_points.char_in_set(c, IPV4_CHAR_SET);
 }
 
 template <typename CharT>
-inline bool isHexChar(CharT c) {
+inline bool is_hex_char(CharT c) {
     return code_points.char_in_set(c, HEX_DIGIT_SET);
 }
 
@@ -410,7 +410,7 @@ extern const char kHexCharLookup[0x10];
 // See HexDigitToValue for the lookup.
 extern const char kCharToHexLookup[8];
 
-// Assumes the input is a valid hex digit! Call isHexChar before using this.
+// Assumes the input is a valid hex digit! Call is_hex_char before using this.
 inline unsigned char HexCharToValue(unsigned char c) noexcept {
     return c - kCharToHexLookup[c / 0x20];
 }
@@ -429,7 +429,7 @@ inline unsigned char HexCharToValue(unsigned char c) noexcept {
 template <typename CharT>
 inline bool DecodeEscaped(const CharT*& first, const CharT* last, unsigned char& unescaped_value) {
     if (last - first < 2 ||
-        !isHexChar(first[0]) || !isHexChar(first[1])) {
+        !is_hex_char(first[0]) || !is_hex_char(first[1])) {
         // not enough or invalid hex digits
         return false;
     }
@@ -495,7 +495,7 @@ void AppendStringOfType(const CharT* first, const CharT* last, const code_point_
         } else {
             // Just append the 7-bit character, possibly escaping it.
             const auto uch = static_cast<unsigned char>(ch);
-            if (isCharInSet(uch, cpset)) {
+            if (is_char_in_set(uch, cpset)) {
                 output.push_back(uch);
             } else {
                 // other characters are escaped

--- a/include/upa/url_percent_encode.h
+++ b/include/upa/url_percent_encode.h
@@ -407,11 +407,11 @@ extern const char kHexCharLookup[0x10];
 // contains the amount to subtract from characters in that range to get at
 // the corresponding numerical value.
 //
-// See HexDigitToValue for the lookup.
+// See hex_char_to_num for the lookup.
 extern const char kCharToHexLookup[8];
 
 // Assumes the input is a valid hex digit! Call is_hex_char before using this.
-inline unsigned char HexCharToValue(unsigned char c) noexcept {
+inline unsigned char hex_char_to_num(unsigned char c) noexcept {
     return c - kCharToHexLookup[c / 0x20];
 }
 
@@ -427,7 +427,7 @@ inline unsigned char HexCharToValue(unsigned char c) noexcept {
 // sequence. On failure, |*first| will be unchanged.
 
 template <typename CharT>
-inline bool DecodeEscaped(const CharT*& first, const CharT* last, unsigned char& unescaped_value) {
+inline bool decode_hex_to_byte(const CharT*& first, const CharT* last, unsigned char& unescaped_value) {
     if (last - first < 2 ||
         !is_hex_char(first[0]) || !is_hex_char(first[1])) {
         // not enough or invalid hex digits
@@ -437,7 +437,7 @@ inline bool DecodeEscaped(const CharT*& first, const CharT* last, unsigned char&
     // Valid escape sequence.
     const auto uc1 = static_cast<unsigned char>(first[0]);
     const auto uc2 = static_cast<unsigned char>(first[1]);
-    unescaped_value = (HexCharToValue(uc1) << 4) + HexCharToValue(uc2);
+    unescaped_value = (hex_char_to_num(uc1) << 4) + hex_char_to_num(uc2);
     first += 2;
     return true;
 }
@@ -535,7 +535,7 @@ inline std::string percent_decode(StrT&& str) {
             }
             // uch == '%'
             unsigned char uc8; // NOLINT(cppcoreguidelines-init-variables)
-            if (detail::DecodeEscaped(it, last, uc8)) {
+            if (detail::decode_hex_to_byte(it, last, uc8)) {
                 if (uc8 < 0x80) {
                     out.push_back(static_cast<char>(uc8));
                     continue;
@@ -545,7 +545,7 @@ inline std::string percent_decode(StrT&& str) {
                 buff_utf8.push_back(static_cast<char>(uc8));
                 while (it != last && *it == '%') {
                     ++it; // skip '%'
-                    if (!detail::DecodeEscaped(it, last, uc8))
+                    if (!detail::decode_hex_to_byte(it, last, uc8))
                         uc8 = '%';
                     buff_utf8.push_back(static_cast<char>(uc8));
                 }

--- a/include/upa/url_search_params.h
+++ b/include/upa/url_search_params.h
@@ -701,7 +701,7 @@ inline url_search_params::name_value_list url_search_params::do_parse(bool rem_q
                 const auto uc1 = static_cast<unsigned char>(*(++itc));
                 const auto uc2 = static_cast<unsigned char>(*(++itc));
                 if (detail::is_hex_char(uc1) && detail::is_hex_char(uc2)) {
-                    const char c = static_cast<char>((detail::HexCharToValue(uc1) << 4) + detail::HexCharToValue(uc2));
+                    const char c = static_cast<char>((detail::hex_char_to_num(uc1) << 4) + detail::hex_char_to_num(uc2));
                     pval->push_back(c);
                     it = itc;
                     break;

--- a/include/upa/url_search_params.h
+++ b/include/upa/url_search_params.h
@@ -700,7 +700,7 @@ inline url_search_params::name_value_list url_search_params::do_parse(bool rem_q
                 auto itc = it;
                 const auto uc1 = static_cast<unsigned char>(*(++itc));
                 const auto uc2 = static_cast<unsigned char>(*(++itc));
-                if (detail::isHexChar(uc1) && detail::isHexChar(uc2)) {
+                if (detail::is_hex_char(uc1) && detail::is_hex_char(uc2)) {
                     const char c = static_cast<char>((detail::HexCharToValue(uc1) << 4) + detail::HexCharToValue(uc2));
                     pval->push_back(c);
                     it = itc;


### PR DESCRIPTION
Rename:
* `isCharInSet` -> `is_char_in_set`
* `isIPv4Char` -> `is_ipv4_char`
* `isHexChar` -> `is_hex_char`
* `HexCharToValue` -> `hex_char_to_num`
* `DecodeEscaped` -> `decode_hex_to_byte`
* `AppendEscapedChar` -> `append_percent_encoded_byte`
* `AppendUTF8EscapedChar` -> `append_utf8_percent_encoded_char`
* `AppendStringOfType` -> `append_utf8_percent_encoded`

Remove `AppendUTF8EscapedValue` function and move its content to `append_utf8_percent_encoded_char` function. Update comments.