### PR TITLE
Add `format` parameter to `url_from_file_path` function and accept `/` in any Windows path

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -2940,7 +2940,7 @@ inline void url_setter::insert_part(url::PartType new_pt, const char* str, std::
 template <typename CharT>
 inline bool is_unc_path(const CharT* first, const CharT* last)
 {
-    // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsc/149a3039-98ce-491a-9268-2f5ddef08192
+    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dfsc/149a3039-98ce-491a-9268-2f5ddef08192
     std::size_t path_components_count = 0;
     const auto* start = first;
     while (start != last) {
@@ -3016,8 +3016,8 @@ inline url url_from_file_path(StrT&& str) {
         // Windows path?
         bool is_unc = false;
 
-        // https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
-        // https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+        // https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
         if (detail::starts_with(pointer, last, { "\\\\", 2 })) {
             pointer += 2; // skip '\\'
 

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -599,10 +599,12 @@ TEST_CASE("url_from_file_path") {
         CHECK(upa::url_from_file_path("/c|\\end").href() == "file:///c%7C%5Cend");
         CHECK(upa::url_from_file_path("/c:/last").href() == "file:///c%3A/last");
         CHECK(upa::url_from_file_path("/c|/last").href() == "file:///c%7C/last");
+        CHECK(upa::url_from_file_path("/\\", upa::file_path_format::posix).href() == "file:///%5C");
         // empty path
         CHECK_THROWS_AS(upa::url_from_file_path(""), upa::url_error);
         // non absolute path
         CHECK_THROWS_AS(upa::url_from_file_path("path"), upa::url_error);
+        CHECK_THROWS_AS(upa::url_from_file_path("\\\\h\\p", upa::file_path_format::posix), upa::url_error);
     }
     SUBCASE("Windows path") {
         // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
@@ -614,17 +616,21 @@ TEST_CASE("url_from_file_path") {
         CHECK(upa::url_from_file_path("\\\\h\\path").href() == "file://h/path");
         CHECK(upa::url_from_file_path("\\\\h\\a/b").href() == "file://h/a/b");
         CHECK(upa::url_from_file_path("\\\\a/b\\path").href() == "file://a/b/path");
+        CHECK(upa::url_from_file_path("//h/path", upa::file_path_format::windows).href() == "file://h/path");
         // https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
         CHECK(upa::url_from_file_path("\\\\?\\D:\\very_long_path").href() == "file:///D:/very_long_path");
         CHECK(upa::url_from_file_path("\\\\?\\UNC\\h\\very_long_path").href() == "file://h/very_long_path");
         CHECK(upa::url_from_file_path("\\\\?/unc/h/very_long_path").href() == "file://h/very_long_path");
-        CHECK(upa::url_from_file_path("\\\\.\\D:\\very_long_path").href() == "file:///D:/very_long_path");
-        CHECK(upa::url_from_file_path("\\\\.\\UNC\\h\\very_long_path").href() == "file://h/very_long_path");
-        CHECK(upa::url_from_file_path("\\\\./unc/h/very_long_path").href() == "file://h/very_long_path");
+        CHECK(upa::url_from_file_path("\\\\.\\D:\\just_path").href() == "file:///D:/just_path");
+        CHECK(upa::url_from_file_path("\\\\.\\UNC\\h\\just_path").href() == "file://h/just_path");
+        CHECK(upa::url_from_file_path("\\\\./unc/h/just_path").href() == "file://h/just_path");
+        CHECK(upa::url_from_file_path("//?/unc/h/very_long_path", upa::file_path_format::windows).href() == "file://h/very_long_path");
+        CHECK(upa::url_from_file_path("//./unc/h/just_path", upa::file_path_format::windows).href() == "file://h/just_path");
         // non absolute path
         CHECK_THROWS_AS(upa::url_from_file_path("\\"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("C:path"), upa::url_error);
+        CHECK_THROWS_AS(upa::url_from_file_path("/", upa::file_path_format::windows), upa::url_error);
         // invalid UNC
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\h"), upa::url_error);

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -605,15 +605,15 @@ TEST_CASE("url_from_file_path") {
         CHECK_THROWS_AS(upa::url_from_file_path("path"), upa::url_error);
     }
     SUBCASE("Windows path") {
-        // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
         CHECK(upa::url_from_file_path("C:\\").href() == "file:///C:/");
         CHECK(upa::url_from_file_path("C:\\path").href() == "file:///C:/path");
         CHECK(upa::url_from_file_path("C|\\path").href() == "file:///C:/path");
         CHECK(upa::url_from_file_path("C:/path").href() == "file:///C:/path");
         CHECK(upa::url_from_file_path("C:\\path %#").href() == "file:///C:/path%20%25%23");
         CHECK(upa::url_from_file_path("\\\\h\\path").href() == "file://h/path");
-        // https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
-        // https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+        // https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
         CHECK(upa::url_from_file_path("\\\\?\\D:\\very_long_path").href() == "file:///D:/very_long_path");
         CHECK(upa::url_from_file_path("\\\\?\\UNC\\h\\very_long_path").href() == "file://h/very_long_path");
         CHECK(upa::url_from_file_path("\\\\.\\D:\\very_long_path").href() == "file:///D:/very_long_path");

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -612,12 +612,16 @@ TEST_CASE("url_from_file_path") {
         CHECK(upa::url_from_file_path("C:/path").href() == "file:///C:/path");
         CHECK(upa::url_from_file_path("C:\\path %#").href() == "file:///C:/path%20%25%23");
         CHECK(upa::url_from_file_path("\\\\h\\path").href() == "file://h/path");
+        CHECK(upa::url_from_file_path("\\\\h\\a/b").href() == "file://h/a/b");
+        CHECK(upa::url_from_file_path("\\\\a/b\\path").href() == "file://a/b/path");
         // https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
         CHECK(upa::url_from_file_path("\\\\?\\D:\\very_long_path").href() == "file:///D:/very_long_path");
         CHECK(upa::url_from_file_path("\\\\?\\UNC\\h\\very_long_path").href() == "file://h/very_long_path");
+        CHECK(upa::url_from_file_path("\\\\?/unc/h/very_long_path").href() == "file://h/very_long_path");
         CHECK(upa::url_from_file_path("\\\\.\\D:\\very_long_path").href() == "file:///D:/very_long_path");
         CHECK(upa::url_from_file_path("\\\\.\\UNC\\h\\very_long_path").href() == "file://h/very_long_path");
+        CHECK(upa::url_from_file_path("\\\\./unc/h/very_long_path").href() == "file://h/very_long_path");
         // non absolute path
         CHECK_THROWS_AS(upa::url_from_file_path("\\"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("C:path"), upa::url_error);
@@ -627,8 +631,6 @@ TEST_CASE("url_from_file_path") {
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\h\\"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\h\\\\"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path(std::string{ '\\', '\\', 'h', '\\', 'a', '\0', 'b' }), upa::url_error);
-        CHECK_THROWS_AS(upa::url_from_file_path("\\\\h\\a/b"), upa::url_error);
-        CHECK_THROWS_AS(upa::url_from_file_path("\\\\a/b\\path"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\C:\\path"), upa::url_error);
         CHECK_THROWS_AS(upa::url_from_file_path("\\\\C|\\path"), upa::url_error);
         // invalid hostname


### PR DESCRIPTION
The `format` parameter specifies the format of the given file path - POSIX or Windows. It can have any of the following values:
* `upa::file_path_format::detect` - detect file path format from first character: `/` - POSIX, otherwise - Windows
* `upa::file_path_format::posix` - POSIX file path format
* `upa::file_path_format::windows` - Windows file path format
* `upa::file_path_format::native` - the file path format corresponds to the OS on which the code was compiled
