### PR TITLE
Add `idna_unicode_version` and `make_unicode_version` functions

### DIFF
--- a/include/upa/url_idna.h
+++ b/include/upa/url_idna.h
@@ -33,6 +33,29 @@ validation_errc domain_to_ascii(const char16_t* src, std::size_t src_len, simple
 /// @return `validation_errc::ok` on success, or error code on failure
 validation_errc domain_to_unicode(const char* src, std::size_t src_len, simple_buffer<char>& output);
 
+/// @brief Gets Unicode version that IDNA library conforms to
+///
+/// @return encoded Unicode version
+/// @see make_unicode_version
+unsigned idna_unicode_version();
+
+/// @brief Encodes Unicode version
+///
+/// The version is encoded as follows: <version 1st number> * 0x1000000 +
+/// <version 2nd number> * 0x10000 + <version 3rd number> * 0x100 + <version 4th number>
+///
+/// For example for Unicode version 15.1.0 it returns 0x0F010000
+///
+/// @param[in] n1 version 1st number
+/// @param[in] n2 version 2nd number
+/// @param[in] n3 version 3rd number
+/// @param[in] n4 version 4th number
+/// @return encoded Unicode version
+constexpr unsigned make_unicode_version(unsigned n1, unsigned n2 = 0,
+    unsigned n3 = 0, unsigned n4 = 0) {
+    return n1 << 24 | n2 << 16 | n3 << 8 | n4;
+}
+
 /// @brief Close the IDNA handles, conditionally close the IDNA library, and free its memory
 ///
 /// It closes IDNA handles opened by calls to domain_to_ascii or domain_to_unicode functions.

--- a/src/url_idna.cpp
+++ b/src/url_idna.cpp
@@ -69,7 +69,7 @@ void idna_close(bool close_lib) {
 
 unsigned idna_unicode_version() {
     UVersionInfo ver;
-    u_getUnicodeVersion(ver);
+    u_getUnicodeVersion(ver); // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
     return make_unicode_version(ver[0], ver[1], ver[2], ver[3]);
 }
 

--- a/src/url_idna.cpp
+++ b/src/url_idna.cpp
@@ -10,6 +10,7 @@
 #include "upa/url_idna.h"
 #include "upa/util.h"
 // ICU
+#include "unicode/uchar.h"  // u_getUnicodeVersion
 #include "unicode/uclean.h"
 #include "unicode/uidna.h"
 #if (U_ICU_VERSION_MAJOR_NUM) >= 59
@@ -64,6 +65,12 @@ void idna_close(bool close_lib) {
         // ICU cleanup
         u_cleanup();
     }
+}
+
+unsigned idna_unicode_version() {
+    UVersionInfo ver;
+    u_getUnicodeVersion(ver);
+    return make_unicode_version(ver[0], ver[1], ver[2], ver[3]);
 }
 
 // Conversion to ICU UChar

--- a/test/wpt-url.cpp
+++ b/test/wpt-url.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <map>
 #include <string>
-#include <unicode/uversion.h>
 
 
 // Test runner
@@ -40,10 +39,11 @@ int main(int argc, char** argv)
     err |= test_from_file(run_host_parser_tests, "wpt/toascii.json");
     err |= test_from_file(run_setter_tests, "wpt/setters_tests.json");
     err |= test_from_file(run_percent_encoding_tests, "wpt/percent-encoding.json");
-#if (U_ICU_VERSION_MAJOR_NUM) >= 66
-    // Only ICU 66.1 or latter passes all IdnaTestV2.json tests
-    err |= test_from_file(run_idna_v2_tests, "wpt/IdnaTestV2.json");
-#endif
+    if (upa::idna_unicode_version() >= upa::make_unicode_version(13)) {
+        // Only the IDNA library that conforms to Unicode 13.0 or later
+        // (e.g., ICU 66.1 or later) passes all IdnaTestV2.json tests
+        err |= test_from_file(run_idna_v2_tests, "wpt/IdnaTestV2.json");
+    }
 
     // additional tests
     err |= test_from_file(run_parser_tests, "data/my-urltestdata.json");


### PR DESCRIPTION
They are used in `wpt-url.cpp` to run `IdnaTestV2.json` tests only if the IDNA library supports Unicode 13.0 or later (e.g. is ICU 66.1 or later).