### PR TITLE
Make `url::search_params()` safer to use

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -493,7 +493,13 @@ public:
     /// operation (except @c safe_assign, which preserves reference validity).
     ///
     /// @return reference to this’s query object (url_search_params class)
-    url_search_params& search_params();
+    url_search_params& search_params()&;
+
+    /// @brief The searchParams getter for rvalue url
+    ///
+    /// @return the move constructed copy of this’s query object (url_search_params class)
+    /// @see search_params()&
+    url_search_params search_params()&&;
 
     /// @brief URL serializer
     ///
@@ -1194,10 +1200,19 @@ inline string_view url::hash() const {
     return { norm_url_.data() + b, e - b };
 }
 
-inline url_search_params& url::search_params() {
+inline url_search_params& url::search_params()& {
     if (!search_params_ptr_)
         search_params_ptr_.init(this);
     return *search_params_ptr_;
+}
+
+inline url_search_params url::search_params()&& {
+    if (search_params_ptr_) {
+        auto tmp = std::move(*search_params_ptr_);
+        tmp.url_ptr_ = nullptr;
+        return tmp;
+    }
+    return url_search_params{ search() };
 }
 
 inline void url::clear_search_params() noexcept {

--- a/test/test-url_search_params.cpp
+++ b/test/test-url_search_params.cpp
@@ -338,6 +338,37 @@ TEST_CASE("url::search_params()") {
     CHECK(url.search() == "");
 }
 
+TEST_CASE("url::search_params() of rvalue url object") {
+    const char* str_url = "http://h/" TEST_SEARCH_STR;
+    // expected values
+    const std::pair<std::string, std::string> arr_pairs[] = TEST_ITERABLES_DATA;
+    // TODO: use std::size(arr_pairs) if C++17
+    const std::size_t count = std::distance(std::begin(arr_pairs), std::end(arr_pairs));
+
+    SUBCASE("temporary url") {
+        std::size_t ind = 0;
+        for (auto& item : upa::url(str_url).search_params()) {
+            REQUIRE(ind < count);
+            CHECK(item == arr_pairs[ind]);
+            ++ind;
+        }
+        CHECK(ind == count);
+    }
+
+    SUBCASE("moved url") {
+        upa::url url{ str_url };
+        url.search_params();
+
+        std::size_t ind = 0;
+        for (auto& item : std::move(url).search_params()) {
+            REQUIRE(ind < count);
+            CHECK(item == arr_pairs[ind]);
+            ++ind;
+        }
+        CHECK(ind == count);
+    }
+}
+
 TEST_CASE("url::search_params() and url::operator=(const url&)") {
     // test copy assignment to url with initialized url_search_params
     upa::url url_ca("http://dest/");


### PR DESCRIPTION
Made it possible to use `url::search_params()` when the `url` object is rvalue.