### PR TITLE
Fix `url_search_params` move constructor

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -1207,11 +1207,8 @@ inline url_search_params& url::search_params()& {
 }
 
 inline url_search_params url::search_params()&& {
-    if (search_params_ptr_) {
-        auto tmp = std::move(*search_params_ptr_);
-        tmp.url_ptr_ = nullptr;
-        return tmp;
-    }
+    if (search_params_ptr_)
+        return std::move(*search_params_ptr_);
     return url_search_params{ search() };
 }
 

--- a/include/upa/url_search_params.h
+++ b/include/upa/url_search_params.h
@@ -101,7 +101,7 @@ public:
     /// using move semantics.
     ///
     /// @param[in,out] other @c url_search_params object to move from
-    url_search_params(url_search_params&& other) = default;
+    url_search_params(url_search_params&& other);
 
     /// @brief Parsing constructor.
     ///
@@ -440,6 +440,13 @@ private:
 
 inline url_search_params::url_search_params(const url_search_params& other)
     : params_(other.params_)
+    , is_sorted_(other.is_sorted_)
+{}
+
+// Move constructor
+
+inline url_search_params::url_search_params(url_search_params&& other)
+    : params_(std::move(other.params_))
     , is_sorted_(other.is_sorted_)
 {}
 

--- a/include/upa/url_search_params.h
+++ b/include/upa/url_search_params.h
@@ -101,7 +101,8 @@ public:
     /// using move semantics.
     ///
     /// @param[in,out] other @c url_search_params object to move from
-    url_search_params(url_search_params&& other);
+    url_search_params(url_search_params&& other)
+        noexcept(std::is_nothrow_move_constructible<name_value_list>::value);
 
     /// @brief Parsing constructor.
     ///
@@ -446,6 +447,7 @@ inline url_search_params::url_search_params(const url_search_params& other)
 // Move constructor
 
 inline url_search_params::url_search_params(url_search_params&& other)
+    noexcept(std::is_nothrow_move_constructible<name_value_list>::value)
     : params_(std::move(other.params_))
     , is_sorted_(other.is_sorted_)
 {}

--- a/test/test-url_search_params.cpp
+++ b/test/test-url_search_params.cpp
@@ -369,6 +369,18 @@ TEST_CASE("url::search_params() of rvalue url object") {
     }
 }
 
+TEST_CASE("moved url::search_params()") {
+    const char* str_url = "http://h/" TEST_SEARCH_STR;
+
+    upa::url url{ str_url };
+    // usp.url_ptr_ must be nullptr after move construction,
+    // i.e. must not be connected to url
+    upa::url_search_params usp{ std::move(url.search_params()) };
+    const auto str = url.to_string();
+    usp.append("p", "priv");
+    CHECK(str == url.to_string());
+}
+
 TEST_CASE("url::search_params() and url::operator=(const url&)") {
     // test copy assignment to url with initialized url_search_params
     upa::url url_ca("http://dest/");


### PR DESCRIPTION
`url_search_params` move constructor has been modified to not copy the `url_ptr_` value, but to assign `nullptr` to it. How the copy constructor and assignment operator behave.

This allowed to simplify the `url::search_params()&&` function.