### PR TITLE
Disallow dot-dot segments in the path argument of url_from_file_path

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -3033,7 +3033,8 @@ inline bool has_dot_dot_segment(const CharT* first, const CharT* last, IsSlash i
                 (last - ptr == 2 || is_slash(ptr[2])))
                 return true;
             // skip '.' and following char
-            if ((ptr += 2) >= end)
+            ptr += 2;
+            if (ptr >= end)
                 break;
         }
     }


### PR DESCRIPTION
To deal with dot-dot segments, it is recommended to use a special OS function to normalize the path before passing it to the `upa::url_from_file_path` function. Normalization can be done using the POSIX [`realpath`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html) function, the Windows [`GetFullPathName`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamew) function, or, if you are using C++17, the [`std::filesystem::canonical`](https://en.cppreference.com/w/cpp/filesystem/canonical) function.