### PR TITLE
Fix building on GitHub Actions macOS CI

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -27,10 +27,10 @@ jobs:
       run: brew install icu4c
     - name: get dependencies
       run: ./init.sh
+    - name: set ICU_ROOT
+      run: echo "ICU_ROOT=$(if [ "${{ runner.arch }}" = "ARM64" ]; then echo '/opt/homebrew/opt/icu4c'; else echo '/usr/local/opt/icu4c'; fi)" >> $GITHUB_ENV
     - name: cmake
       run: cmake -S . -B build -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
-      env:
-        ICU_ROOT: /usr/local/opt/icu4c
     - name: build
       run: cmake --build build --config Release
     - name: test


### PR DESCRIPTION
Homebrew uses the following installation prefixes:
* `/usr/local` for macOS on Intel
* `/opt/homebrew` for macOS on Apple Silicon/ARM

See: https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location