### PR TITLE
Fix `host_parser::parse_host` function

### DIFF
--- a/include/upa/url_host.h
+++ b/include/upa/url_host.h
@@ -195,9 +195,13 @@ inline validation_errc host_parser::parse_host(const CharT* first, const CharT* 
             return validation_errc::ok;
         }
     } else if (static_cast<UCharT>(*ptr) < 0x80 && *ptr != '%') {
-        // 7. If asciiDomain contains a forbidden domain code point, domain-invalid-code-point
-        // validation error, return failure. 
-        return validation_errc::domain_invalid_code_point;
+        // NFC normalizes U+003C (<), U+003D (=), U+003E (>) characters if they precede
+        // U+0338. Therefore, no errors are reported here for forbidden < and > characters
+        // if there is a possibility to normalize them.
+        if (!(*ptr >= 0x3C && *ptr <= 0x3E && ptr + 1 < last && static_cast<UCharT>(ptr[1]) >= 0x80))
+            // 7. If asciiDomain contains a forbidden domain code point, domain-invalid-code-point
+            // validation error, return failure. 
+            return validation_errc::domain_invalid_code_point;
     }
 
     // Input for domain_to_ascii

--- a/test/data/my-toascii.json
+++ b/test/data/my-toascii.json
@@ -1,0 +1,28 @@
+[
+  {
+    "comment": "NFC normalization (forbidden < and > characters are normalized to valid ones)",
+    "input": "=\u0338",
+    "output": "xn--1ch"
+  },
+  {
+    "input": "<\u0338",
+    "output": "xn--gdh"
+  },
+  {
+    "input": ">\u0338",
+    "output": "xn--hdh"
+  },
+  {
+    "comment": "Same with inserted IDNA ignored code point",
+    "input": "=\u00AD\u0338",
+    "output": "xn--1ch"
+  },
+  {
+    "input": "<\u00AD\u0338",
+    "output": "xn--gdh"
+  },
+  {
+    "input": ">\u00AD\u0338",
+    "output": "xn--hdh"
+  }
+]

--- a/test/wpt-url.cpp
+++ b/test/wpt-url.cpp
@@ -47,6 +47,7 @@ int main(int argc, char** argv)
 
     // additional tests
     err |= test_from_file(run_parser_tests, "data/my-urltestdata.json");
+    err |= test_from_file(run_host_parser_tests, "data/my-toascii.json");
     err |= test_from_file(run_setter_tests, "data/my-setters_tests.json");
 
     // Free memory


### PR DESCRIPTION
Do not report error on forbidden `<` and `>` characters if they are NFC normalized to valid ones.