### PR TITLE
Use ICU's C API only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ environment:
       CXX_STANDARD: 17
 
 install:
-  - install-icu.bat C:\LIB 74 2
+  - install-icu.bat C:\LIB 75 1
 
 before_build:
   - init.bat

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -20,6 +20,12 @@ jobs:
             cxx_standard: 20
             cmake_options: ""
 
+          - name: VS 2022 C++14
+            os: windows-2022
+            generator: "Visual Studio 17 2022"
+            cxx_standard: 14
+            cmake_options: ""
+
           - name: VS 2022 C++23
             os: windows-2022
             generator: "Visual Studio 17 2022"

--- a/LICENSE
+++ b/LICENSE
@@ -59,8 +59,8 @@ project licensed as follows:
 
 -------------------------------------------------------------------------------
 
-Files url_utf.cpp, url_utf.h contains portions of modified code from the ICU
-project licensed as follows:
+Files config.h, url_utf.cpp, url_utf.h contains portions of modified code from
+the ICU project licensed as follows:
 
 UNICODE LICENSE V3
 

--- a/include/upa/config.h
+++ b/include/upa/config.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2023 Rimas Misevičius
+// Copyright 2016-2024 Rimas Misevičius
 // Distributed under the BSD-style license that can be
 // found in the LICENSE file.
 //
@@ -37,6 +37,18 @@
 # define UPA_CONSTEXPR_14 constexpr
 #else
 # define UPA_CONSTEXPR_14 inline
+#endif
+
+// Barrier for pointer anti-aliasing optimizations even across function boundaries.
+// This is a slightly modified U_ALIASING_BARRIER macro from the char16ptr.h file
+// of the ICU 75.1 library.
+// Discussion: https://github.com/sg16-unicode/sg16/issues/67
+#ifndef UPA_ALIASING_BARRIER
+# if defined(__clang__) || defined(__GNUC__)
+#  define UPA_ALIASING_BARRIER(ptr) asm volatile("" : : "rm"(ptr) : "memory");  // NOLINT(*-macro-*,hicpp-no-assembler)
+# else
+#  define UPA_ALIASING_BARRIER(ptr)
+# endif
 #endif
 
 #endif // UPA_CONFIG_H


### PR DESCRIPTION
What is done:
* Replace the C++ ICU function `icu::toUCharPtr` with the locally implemented `to_UChar_ptr` function.
* Use `u_getVersion` function to get ICU major version

Benefits:
* Using ICU's C API only allows the program to run with a different version of ICU than the compiled one.
* ICU 75.1 C++ API requires C++17. When using the C API only, a C++11 or C++14 compiler can be used.

See also: https://unicode-org.github.io/icu/userguide/icu4c/build.html#icu-as-a-system-level-library