### PR TITLE
Add support for ICU library bundled with Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -26,6 +26,12 @@ jobs:
             cxx_standard: 14
             cmake_options: ""
 
+          - name: VS 2022 C++17 (Windows ICU)
+            os: windows-2022
+            generator: "Visual Studio 17 2022"
+            cxx_standard: 17
+            cmake_options: "-DUPA_USE_WINDOWS_ICU=ON"
+
           - name: VS 2022 C++23
             os: windows-2022
             generator: "Visual Studio 17 2022"
@@ -47,7 +53,9 @@ jobs:
       run: init.bat
       shell: cmd
     - name: cmake
-      run: cmake -S . -B build -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} -DICU_ROOT=C:\LIB\ICU ${{ matrix.cmake_options }}
+      run: cmake -S . -B build -G "${{ matrix.generator }}" -A x64 -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} ${{ matrix.cmake_options }}
+      env:
+        ICU_ROOT: C:\LIB\ICU
     - name: build
       run: cmake --build build --config Release
     - name: test

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,12 +19,14 @@ jobs:
             generator: "Visual Studio 16 2019"
             cxx_standard: 20
             cmake_options: ""
+            install_icu: true
 
           - name: VS 2022 C++14
             os: windows-2022
             generator: "Visual Studio 17 2022"
             cxx_standard: 14
             cmake_options: ""
+            install_icu: true
 
           - name: VS 2022 C++17 (Windows ICU)
             os: windows-2022
@@ -37,16 +39,19 @@ jobs:
             generator: "Visual Studio 17 2022"
             cxx_standard: 23
             cmake_options: ""
+            install_icu: true
 
           - name: VS 2022 Clang C++20
             os: windows-2022
             generator: "Visual Studio 17 2022"
             cxx_standard: 20
             cmake_options: "-T ClangCL"
+            install_icu: true
 
     steps:
     - uses: actions/checkout@v4
     - name: install ICU library
+      if: matrix.install_icu
       run: install-icu.bat C:\LIB 75 1
       shell: cmd
     - name: get dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ project(upa_url VERSION ${UPA_URL_VERSION} LANGUAGES CXX)
 # ${upa_lib_name}-config.cmake
 # It also must be used as the package name argument to find_package
 set(upa_lib_name upa)
+set(upa_lib_name_in upa-icu)
 # Exported name for library target files; also used to create an alias
 # target: upa::${upa_lib_export}
 set(upa_lib_export url)
@@ -143,6 +144,7 @@ if (UPA_BUILD_TESTS OR UPA_BUILD_BENCH OR UPA_BUILD_FUZZER OR UPA_BUILD_EXAMPLES
     EXPORT_NAME ${upa_lib_export})
   if (UPA_USE_WINDOWS_ICU)
     target_compile_definitions(${upa_lib_target} PRIVATE UPA_USE_WINDOWS_ICU=1)
+    set(upa_lib_name_in ${upa_lib_name})
   else()
     target_include_directories(${upa_lib_target} PRIVATE ${ICU_INCLUDE_DIR})
     target_link_libraries(${upa_lib_target} INTERFACE ICU::i18n ICU::uc)
@@ -271,7 +273,7 @@ if (UPA_INSTALL AND NOT UPA_AMALGAMATED)
 
   # generate the config file that includes the exports
   configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${upa_lib_name}-config.cmake.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${upa_lib_name_in}-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${upa_lib_name}-config.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${upa_lib_name}
     NO_SET_AND_CHECK_MACRO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(UPA_BUILD_TOOLS "Build tools." OFF)
 option(UPA_INSTALL "Generate the install target." ON)
 # library options
 option(UPA_AMALGAMATED "Use amalgamated URL library source." OFF)
+option(UPA_USE_WINDOWS_ICU "Use ICU library bundled with Windows 10 version 1903 or later." OFF)
 # tests build options
 option(UPA_TEST_COVERAGE "Build tests with code coverage reporting" OFF)
 option(UPA_TEST_COVERAGE_CLANG "Build tests with Clang source-based code coverage" OFF)
@@ -115,8 +116,10 @@ include_directories(deps)
 # Are Upa URL and ICU libraries needed?
 if (UPA_BUILD_TESTS OR UPA_BUILD_BENCH OR UPA_BUILD_FUZZER OR UPA_BUILD_EXAMPLES OR
     UPA_BUILD_EXTRACTED OR UPA_INSTALL OR NOT UPA_BUILD_TOOLS)
-  # This library depends on ICU
-  find_package(ICU REQUIRED COMPONENTS i18n uc)
+  if (NOT UPA_USE_WINDOWS_ICU)
+    # This library depends on ICU
+    find_package(ICU REQUIRED COMPONENTS i18n uc)
+  endif()
 
   if (UPA_AMALGAMATED)
     add_library(${upa_lib_target} STATIC
@@ -138,8 +141,12 @@ if (UPA_BUILD_TESTS OR UPA_BUILD_BENCH OR UPA_BUILD_FUZZER OR UPA_BUILD_EXAMPLES
   add_library(upa::${upa_lib_export} ALIAS ${upa_lib_target})
   set_target_properties(${upa_lib_target} PROPERTIES
     EXPORT_NAME ${upa_lib_export})
-  target_include_directories(${upa_lib_target} PRIVATE ${ICU_INCLUDE_DIR})
-  target_link_libraries(${upa_lib_target} INTERFACE ICU::i18n ICU::uc)
+  if (UPA_USE_WINDOWS_ICU)
+    target_compile_definitions(${upa_lib_target} PRIVATE UPA_USE_WINDOWS_ICU=1)
+  else()
+    target_include_directories(${upa_lib_target} PRIVATE ${ICU_INCLUDE_DIR})
+    target_link_libraries(${upa_lib_target} INTERFACE ICU::i18n ICU::uc)
+  endif()
 endif()
 
 # Test targets

--- a/cmake/upa-config.cmake.in
+++ b/cmake/upa-config.cmake.in
@@ -1,6 +1,3 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
-find_dependency(ICU REQUIRED COMPONENTS i18n uc)
-
 include("${CMAKE_CURRENT_LIST_DIR}/upa-targets.cmake")

--- a/cmake/upa-icu-config.cmake.in
+++ b/cmake/upa-icu-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(ICU REQUIRED COMPONENTS i18n uc)
+
+include("${CMAKE_CURRENT_LIST_DIR}/upa-targets.cmake")

--- a/src/url_idna.cpp
+++ b/src/url_idna.cpp
@@ -7,16 +7,28 @@
 // Copyright 2013 The Chromium Authors. All rights reserved.
 //
 
+// Define UPA_USE_WINDOWS_ICU = 1 to use the ICU library bundled with
+// Windows 10 version 1903 or later. For more information, see:
+// https://learn.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-
+#ifndef UPA_USE_WINDOWS_ICU
+# define UPA_USE_WINDOWS_ICU 0  // NOLINT(*-macro-*)
+#endif // UPA_USE_WINDOWS_ICU
+
 #include "upa/config.h"
 #include "upa/url_idna.h"
 #include "upa/util.h"
 
+#if UPA_USE_WINDOWS_ICU
+# include <icu.h>
+# pragma comment( lib, "icu" )
+#else
 // ICU: only C API is used (U_SHOW_CPLUSPLUS_API 0)
 // https://unicode-org.github.io/icu/userguide/icu4c/build.html#icu-as-a-system-level-library
-#define U_SHOW_CPLUSPLUS_API 0  // NOLINT(*-macro-*)
-#include "unicode/uchar.h"  // u_getUnicodeVersion
-#include "unicode/uclean.h"
-#include "unicode/uidna.h"
+# define U_SHOW_CPLUSPLUS_API 0  // NOLINT(*-macro-*)
+# include "unicode/uchar.h"  // u_getUnicodeVersion
+# include "unicode/uclean.h"
+# include "unicode/uidna.h"
+#endif
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
This adds the cmake option variable `UPA_USE_WINDOWS_ICU` and a preprocessor macro of the same name for this purpose:
1. For cmake CLI add the option `-DUPA_USE_WINDOWS_ICU=ON`
2. Or define the preprocessor macro `UPA_USE_WINDOWS_ICU = 1` if you are using amalgamated sources
