### PR TITLE
Improve `url::can_parse` performance

### DIFF
--- a/include/upa/url.h
+++ b/include/upa/url.h
@@ -1599,9 +1599,11 @@ inline validation_errc url_parser::url_parse(url_serializer& urls, const CharT* 
     detail::do_remove_whitespace(first, last, buff_no_ws);
     //TODO-WARN: validation error if removed
 
-    // reserve size (TODO: But what if `base` is used?)
-    const auto length = std::distance(first, last);
-    urls.reserve(length + 32);
+    if (urls.need_save()) {
+        // reserve size (TODO: But what if `base` is used?)
+        const auto length = std::distance(first, last);
+        urls.reserve(length + 32);
+    }
 
 #ifdef UPA_URL_USE_ENCODING
     const char* encoding = "UTF-8";

--- a/test/bench-url.cpp
+++ b/test/bench-url.cpp
@@ -36,13 +36,21 @@ int benchmark_txt(const char* file_name, uint64_t min_iters) {
 
     // Run benchmark
 
-    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa URL", [&] {
+    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa url::parse", [&] {
         upa::url url;
 
         for (const auto& str_url : url_strings) {
-            url.parse(str_url, nullptr);
+            url.parse(str_url);
 
             ankerl::nanobench::doNotOptimizeAway(url);
+        }
+    });
+
+    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa url::can_parse", [&] {
+        for (const auto& str_url : url_strings) {
+            bool ok = upa::url::can_parse(str_url);
+
+            ankerl::nanobench::doNotOptimizeAway(ok);
         }
     });
 
@@ -81,20 +89,30 @@ int benchmark_wpt(const char* file_name, uint64_t min_iters) {
 
     // Run benchmark
 
-    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa URL", [&] {
+    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa url::parse", [&] {
         upa::url url;
         upa::url url_base;
 
         for (const auto& url_strings : url_samples) {
             upa::url* ptr_base = nullptr;
             if (!url_strings.second.empty()) {
-                if (!upa::success(url_base.parse(url_strings.second, nullptr)))
+                if (!upa::success(url_base.parse(url_strings.second)))
                     continue; // invalid base
                 ptr_base = &url_base;
             }
             url.parse(url_strings.first, ptr_base);
 
             ankerl::nanobench::doNotOptimizeAway(url);
+        }
+    });
+
+    ankerl::nanobench::Bench().minEpochIterations(min_iters).run("Upa url::can_parse", [&] {
+        for (const auto& url_strings : url_samples) {
+            bool ok = url_strings.second.empty()
+                ? upa::url::can_parse(url_strings.first)
+                : upa::url::can_parse(url_strings.first, url_strings.second);
+
+            ankerl::nanobench::doNotOptimizeAway(ok);
         }
     });
 

--- a/test/fuzz-url.cpp
+++ b/test/fuzz-url.cpp
@@ -55,8 +55,10 @@ extern "C" int LLVMFuzzerTestOneInput(const char* data, std::size_t size) {
 
     // Parse input data against base URL
     upa::string_view inp{ data, size };
+    bool parse_ok = false;
     try {
         upa::url u1{ inp, pbase };
+        parse_ok = true;
         reparse_test(u1);
     }
     catch (upa::url_error&) {
@@ -65,5 +67,10 @@ extern "C" int LLVMFuzzerTestOneInput(const char* data, std::size_t size) {
     catch (std::exception&) {
         assert(false);
     }
+
+    // url::can_parse
+    const bool can_parse_ok = upa::url::can_parse(inp, pbase);
+    assert(can_parse_ok == parse_ok);
+
     return 0;
 }

--- a/test/test-url.cpp
+++ b/test/test-url.cpp
@@ -369,6 +369,9 @@ TEST_CASE("Parse URL with invalid base") {
         CHECK(url.is_valid());
         CHECK(url.parse("https://h/", base) == upa::validation_errc::invalid_base);
         CHECK_FALSE(url.is_valid());
+
+        // url::can_parse
+        CHECK_FALSE(upa::url::can_parse("about:blank", base));
     }
     SUBCASE("Invalid base") {
         upa::url base;
@@ -386,6 +389,9 @@ TEST_CASE("Parse URL with invalid base") {
         CHECK(url.is_valid());
         CHECK(url.parse("https://h/", base) == upa::validation_errc::invalid_base);
         CHECK_FALSE(url.is_valid());
+
+        // url::can_parse
+        CHECK_FALSE(upa::url::can_parse("about:blank", base));
     }
 }
 

--- a/test/wpt-url.cpp
+++ b/test/wpt-url.cpp
@@ -127,6 +127,20 @@ void test_parser(DataDrivenTest& ddt, ParserObj& obj)
             // check "failure"
             tc.assert_equal(obj.failure, !parse_success, "parse failure WITH NO BASE");
         }
+
+        // Test url::can_parse
+
+        bool can_parse_success = base.empty()
+            ? upa::url::can_parse(input)
+            : upa::url::can_parse(input, base);
+
+        // check "success"
+        tc.assert_equal(!obj.failure, can_parse_success, "can_parse");
+
+        if (obj.failure && !base.empty()) {
+            can_parse_success = upa::url::can_parse(input);
+            tc.assert_equal(!obj.failure, can_parse_success, "can_parse WITH NO BASE");
+        }
     });
 }
 


### PR DESCRIPTION
Only scheme is saved when parsing for `can_parse`, other components are only checked.