### PR TITLE
Update WPT: Move JS-specific URL parser tests into their own file

### DIFF
--- a/test/download-wpt.bat
+++ b/test/download-wpt.bat
@@ -8,8 +8,8 @@ REM
 REM 1. Go to https://github.com/web-platform-tests/wpt/tree/master/url
 REM 2. Find "Latest commit" text and click link next to it.
 REM 3. Copy hash from URL
-set HASH=6a39784534e118acc102cf5252c542378831401d
+set HASH=2b9af57f5f61e06e93a0caff5256d2c435b5c468
 
-for %%f in (setters_tests.json toascii.json urltestdata.json percent-encoding.json IdnaTestV2.json) do (
+for %%f in (setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json) do (
   curl -fsS -o %p%\wpt\%%f https://raw.githubusercontent.com/web-platform-tests/wpt/%HASH%/url/resources/%%f
 )

--- a/test/download-wpt.sh
+++ b/test/download-wpt.sh
@@ -9,9 +9,9 @@ p="$(dirname "$0")"
 # 1. Go to https://github.com/web-platform-tests/wpt/tree/master/url
 # 2. Find "Latest commit" text and click link next to it.
 # 3. Copy hash from URL
-HASH=6a39784534e118acc102cf5252c542378831401d
+HASH=2b9af57f5f61e06e93a0caff5256d2c435b5c468
 
-for f in setters_tests.json toascii.json urltestdata.json percent-encoding.json IdnaTestV2.json
+for f in setters_tests.json toascii.json urltestdata.json urltestdata-javascript-only.json percent-encoding.json IdnaTestV2.json
 do
   curl -fsS -o $p/wpt/$f https://raw.githubusercontent.com/web-platform-tests/wpt/${HASH}/url/resources/$f
 done

--- a/test/wpt-url.cpp
+++ b/test/wpt-url.cpp
@@ -36,6 +36,7 @@ int main(int argc, char** argv)
 
     // URL web-platform-tests
     err |= test_from_file(run_parser_tests, "wpt/urltestdata.json");
+    err |= test_from_file(run_parser_tests, "wpt/urltestdata-javascript-only.json");
     err |= test_from_file(run_host_parser_tests, "wpt/toascii.json");
     err |= test_from_file(run_setter_tests, "wpt/setters_tests.json");
     err |= test_from_file(run_percent_encoding_tests, "wpt/percent-encoding.json");


### PR DESCRIPTION
See: https://github.com/web-platform-tests/wpt/commit/2b9af57f5f61e06e93a0caff5256d2c435b5c468